### PR TITLE
D73-3 | Create Activity Group migration & model

### DIFF
--- a/app/Models/ActivityGroup.php
+++ b/app/Models/ActivityGroup.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class ActivityGroup extends Model
+{
+
+}

--- a/database/migrations/2024_10_23_225813_create_activity_groups_table.php
+++ b/database/migrations/2024_10_23_225813_create_activity_groups_table.php
@@ -15,7 +15,8 @@ return new class extends Migration
             $table->id();
             $table->string('name');
             $table->string('description');
-            $table->boolean('complete');
+            $table->enum('status', ['To Do', 'In Progress', 'Done']);
+            $table->dateTime('completed_at')->nullable();
             $table->timestamps();
         });
     }

--- a/database/migrations/2024_10_23_225813_create_activity_groups_table.php
+++ b/database/migrations/2024_10_23_225813_create_activity_groups_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('activity_groups', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->string('description');
+            $table->boolean('complete');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('activity_groups');
+    }
+};


### PR DESCRIPTION
# [D73-3] | Create an `ActivityGroup` migration & model
- Epic: [D73-4]

## Work
Create an `ActivityGroup` model and migration to store various activity groups. This should store `name`, `description`, `status` and `completed_at`.

## Testing
- Run `php artisan migrate`

### Acceptance Criteria 1 
**WHEN** I have ran the migration
**THEN** the `activity_group` table is created within the database.

### Acceptance Criteria 2
**WHEN** I create an instance of the `ActivityGroup` model
**AND** I populate all of the fields
**THEN** a row is populated in the database.

[RM-2]: https://rheannemcintosh.atlassian.net/browse/RM-2?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RM-4]: https://rheannemcintosh.atlassian.net/browse/RM-4?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[D73-3]: https://rheannemcintosh.atlassian.net/browse/D73-3?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[D73-4]: https://rheannemcintosh.atlassian.net/browse/D73-4?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ