### PR TITLE
D73-6 | Show all Activity Groups

### DIFF
--- a/app/Http/Controllers/ActivityGroupController.php
+++ b/app/Http/Controllers/ActivityGroupController.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\ActivityGroup;
+
+class ActivityGroupController extends Controller
+{
+    /**
+     * Display all activity groups.
+     */
+    public function index()
+    {
+        //
+    }
+
+    /**
+     * Store a newly created resource in storage.
+     */
+    public function store(Request $request)
+    {
+        //
+    }
+
+    /**
+     * Display the specified resource.
+     */
+    public function show(string $id)
+    {
+        //
+    }
+
+    /**
+     * Update the specified resource in storage.
+     */
+    public function update(Request $request, string $id)
+    {
+        //
+    }
+
+    /**
+     * Remove the specified resource from storage.
+     */
+    public function destroy(string $id)
+    {
+        //
+    }
+}

--- a/app/Http/Controllers/ActivityGroupController.php
+++ b/app/Http/Controllers/ActivityGroupController.php
@@ -11,7 +11,14 @@ class ActivityGroupController extends Controller
      */
     public function index()
     {
-        //
+        return response()->json(
+            ActivityGroup::select(
+                'id',
+                'name',
+                'description',
+                'status'
+            )->get()
+        );
     }
 
     /**

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,8 +1,11 @@
 <?php
 
+use App\Http\Controllers\ActivityGroupController;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
 
 Route::get('/user', function (Request $request) {
     return $request->user();
 })->middleware('auth:sanctum');
+
+Route::apiResource('activity-groups', ActivityGroupController::class);


### PR DESCRIPTION
# [D73-6] | Show all Activity Groups
- Epic: [D73-5]

## Work
Creates an API resource for activity groups and returns all activity groups.

## Testing
- Visit http://discover-73-api.test/api/activity-groups

### Acceptance Criteria 1 
**WHEN** I visit the index API route `/activity-groups`
**THEN** all activity groups are returned, including the `id`, `name`, `description` and `status`.

[D73-6]: https://rheannemcintosh.atlassian.net/browse/D73-6?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[D73-5]: https://rheannemcintosh.atlassian.net/browse/D73-5?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ