### PR TITLE
D73-11 | Store an Activity Group

### DIFF
--- a/app/Http/Controllers/ActivityGroupController.php
+++ b/app/Http/Controllers/ActivityGroupController.php
@@ -2,7 +2,10 @@
 
 namespace App\Http\Controllers;
 
+use App\Http\Requests\StoreActivityGroupRequest;
 use App\Models\ActivityGroup;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Validator;
 
 class ActivityGroupController extends Controller
 {
@@ -24,9 +27,23 @@ class ActivityGroupController extends Controller
     /**
      * Store a newly created resource in storage.
      */
-    public function store(Request $request)
+    public function store(StoreActivityGroupRequest $request)
     {
-        //
+        try {
+            $activityGroup = ActivityGroup::create($request->validated());
+
+            return response()->json([
+                'success' => true,
+                'data' => $activityGroup
+            ], 201);
+
+        } catch (\Exception $e) {
+            return response()->json([
+                'success' => false,
+                'message' => 'An error occurred while creating the activity group',
+                'error' => $e->getMessage()
+            ], 500);
+        }
     }
 
     /**

--- a/app/Http/Requests/StoreActivityGroupRequest.php
+++ b/app/Http/Requests/StoreActivityGroupRequest.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Http\Request;
+
+class StoreActivityGroupRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'name' => 'required|string|max:255',
+            'description' => 'nullable|string',
+            'status' => 'required|in:To Do,In Progress,Done' // enum values for status
+        ];
+    }
+
+    /**
+     * Customize the error messages for validation failures.
+     *
+     * @return array
+     */
+    public function messages()
+    {
+        return [
+            'status.in' => 'The status must be one of: To Do, In Progress, or Done.'
+        ];
+    }
+}

--- a/app/Models/ActivityGroup.php
+++ b/app/Models/ActivityGroup.php
@@ -6,5 +6,9 @@ use Illuminate\Database\Eloquent\Model;
 
 class ActivityGroup extends Model
 {
-
+    protected $fillable = [
+        'name',
+        'description',
+        'status'
+    ];
 }


### PR DESCRIPTION
# [D73-11] | Store an Activity Group
- Epic: [D73-5]

## Work
Create an API route that allows an activity group to be stored.

## Testing
- Send a POST request (via POSTMAN) to the following URL, with data: http://discover-73-api.test/api/activity-groups

### Acceptance Criteria 1 
**WHEN** I receive a POST request to the API
**AND** all of the data passes validation
**THEN** an activity group is created and stored in the database.

### Acceptance Criteria 2
**WHEN** I receive a POST request to the API
**AND** all the data does not pass validation
**THEN** a 422 error is thrown, alongside the relevant validation messages.

[D73-11]: https://rheannemcintosh.atlassian.net/browse/D73-11?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[D73-5]: https://rheannemcintosh.atlassian.net/browse/D73-5?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ