### PR TITLE
D73-13 | Destroy an Activity Group

### DIFF
--- a/app/Http/Controllers/ActivityGroupController.php
+++ b/app/Http/Controllers/ActivityGroupController.php
@@ -67,6 +67,20 @@ class ActivityGroupController extends Controller
      */
     public function destroy(string $id)
     {
-        //
+        $activityGroup = ActivityGroup::find($id);
+
+        if (!$activityGroup) {
+            return response()->json([
+                'success' => false,
+                'message' => 'Activity group not found'
+            ], 404);
+        }
+
+        $activityGroup->delete();
+
+        return response()->json([
+            'success' => true,
+            'message' => 'Activity group deleted successfully'
+        ]);
     }
 }


### PR DESCRIPTION
# [D73-13] | Destroy an Activity Group
- Epic: [D73-5]

## Work
Create an API route that allows an activity group to be deleted.

## Testing
- Send a DELETE request (via POSTMAN) to the following URL, using a resource ID which exists: http://discover-73-api.test/api/activity-groups/{ID}

### Acceptance Criteria 1 
**WHEN** I receive a DELETE request to the API
**THEN** an activity group is deleted from the database.

### Acceptance Criteria 1 
**WHEN** I try to DELETE an activity group which does not exist
**THEN** a 404 error is returned.

[D73-13]: https://rheannemcintosh.atlassian.net/browse/D73-13?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[D73-5]: https://rheannemcintosh.atlassian.net/browse/D73-5?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ