### PR TITLE
D73-18 | Create activity migration & model

### DIFF
--- a/app/Models/Activity.php
+++ b/app/Models/Activity.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Activity extends Model
+{
+    protected $fillable = [
+        'name',
+        'activity_group_id',
+        'description',
+        'status',
+        'completed_at'
+    ];
+
+    public function activityGroup()
+    {
+        return $this->belongsTo(ActivityGroup::class);
+    }
+}

--- a/app/Models/ActivityGroup.php
+++ b/app/Models/ActivityGroup.php
@@ -11,4 +11,9 @@ class ActivityGroup extends Model
         'description',
         'status'
     ];
+
+    public function activities()
+    {
+        return $this->hasMany(Activity::class);
+    }
 }

--- a/database/migrations/2024_10_27_201412_create_activities_table.php
+++ b/database/migrations/2024_10_27_201412_create_activities_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('activities', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->foreignId('activity_group_id')->constrained();
+            $table->string('description');
+            $table->enum('status', ['To Do', 'In Progress', 'Done']);
+            $table->dateTime('completed_at')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('activities');
+    }
+};


### PR DESCRIPTION
# [D73-18] | Create activity migration & model
- Epic: [D73-4]

## Work
Create an Activity model and migration to store various activities. This should store `name`, `description`, `status`, `completed_at`, and `activity_group_id`. 

## Testing
- Run `php artisan migrate`

### Acceptance Criteria 1 
**WHEN** I run `php artisan migrate`
**THEN** an `activity` table is created within the database.

### Acceptance Criteria 2
**WHEN** I create an instance of the `Activity` model
**AND** I populate all of the fields
**THEN** a row is populated in the database.

### Acceptance Criteria 3
**WHEN** I have activities attached to an activity group
**THEN** I can access the activities on the activity group model.

### Acceptance Criteria 4
**WHEN** I have activities attached to an activity group
**THEN** I can access the activity group on the activities model.

[D73-18]: https://rheannemcintosh.atlassian.net/browse/D73-18?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[D73-4]: https://rheannemcintosh.atlassian.net/browse/D73-4?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ