### PR TITLE
D73-19 | Return activities belonging to an activity group

### DIFF
--- a/app/Http/Controllers/ActivityGroupController.php
+++ b/app/Http/Controllers/ActivityGroupController.php
@@ -15,8 +15,16 @@ class ActivityGroupController extends Controller
     public function index()
     {
         return response()->json(
-            ActivityGroup::select(
-                'id',
+            ActivityGroup:: with(['activities' => function ($query) {
+                $query->select(
+                    'id',
+                    'name',
+                    'activity_group_id',
+                    'description',
+                    'status'
+                );
+            }])->select(
+        'id',
                 'name',
                 'description',
                 'status'


### PR DESCRIPTION
# [D73-19] | Return activities belonging to an activity group
- Epic: [D73-4]

## Work
Send activities alongside activity groups via the API endpoint (api/activity-groups).

## Testing

### Acceptance Criteria 1 
**WHEN** I visit the index API route /activity-groups
**THEN** all activities are returned alongside their activity groups 

[D73-19]: https://rheannemcintosh.atlassian.net/browse/D73-19?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[D73-4]: https://rheannemcintosh.atlassian.net/browse/D73-4?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ