### PR TITLE
D73-31 | Update the Database Seede

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ yarn-error.log
 /.idea
 /.vscode
 /.zed
+database/seeders/custom

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -2,22 +2,30 @@
 
 namespace Database\Seeders;
 
-use App\Models\User;
-// use Illuminate\Database\Console\Seeds\WithoutModelEvents;
+use Database\Seeders\custom\ActivityGroupSeeder;
+use Database\Seeders\custom\ActivitySeeder;
 use Illuminate\Database\Seeder;
+
+// use Illuminate\Database\Console\Seeds\WithoutModelEvents;
 
 class DatabaseSeeder extends Seeder
 {
+    private array $customSeeders = [
+        'database/seeders/custom/ActivityGroupSeeder.php' => ActivityGroupSeeder::class,
+        'database/seeders/custom/ActivitySeeder.php'      => ActivitySeeder::class,
+    ];
+
     /**
      * Seed the application's database.
      */
     public function run(): void
     {
-        // User::factory(10)->create();
+        $this->call([]);
 
-        User::factory()->create([
-            'name' => 'Test User',
-            'email' => 'test@example.com',
-        ]);
+        foreach ($this->customSeeders as $file => $seederClass) {
+            if (file_exists($file)) {
+                $this->call($seederClass);
+            }
+        }
     }
 }


### PR DESCRIPTION
# [D73-31] | Update the Database Seede

- Epic: [D73-4]

## Work
We should create a system where application related seeders are committed and identifiable seeders are not.

## Testing

### Acceptance Criteria 1
WHEN I run `php artisan db:seed`
THEN all seeders (custom and normal) are run if they exist.

[D73-4]: https://rheannemcintosh.atlassian.net/browse/D73-4?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ